### PR TITLE
Relax property types

### DIFF
--- a/src/font-awesome-icon.ts
+++ b/src/font-awesome-icon.ts
@@ -54,7 +54,7 @@ export class FontAwesomeIconCustomElement {
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/bordered-pulled-icons}
    */
-  @bindable public border: boolean = false;
+  @bindable public border: boolean | 'true' | 'false' = false;
   /**
    * Your own class name that will be added to the SVGElement
    */
@@ -62,14 +62,14 @@ export class FontAwesomeIconCustomElement {
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/fixed-width-icons}
    */
-  @bindable public fixedWidth: boolean = false;
+  @bindable public fixedWidth: boolean | 'true' | 'false' = false;
   @bindable public flip: 'horizontal' | 'vertical' | 'both';
   @bindable public icon: BoundIconArg;
-  @bindable public inverse: boolean = false;
+  @bindable public inverse: boolean | 'true' | 'false' = false;
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/icons-in-a-list}
    */
-  @bindable public listItem: boolean = false;
+  @bindable public listItem: boolean | 'true' | 'false' = false;
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/masking}
    */
@@ -78,11 +78,11 @@ export class FontAwesomeIconCustomElement {
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/animating-icons}
    */
-  @bindable public pulse: boolean = false;
+  @bindable public pulse: boolean | 'true' | 'false' = false;
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/rotating-icons}
    */
-  @bindable public rotation?: 90 | 180 | 270;
+  @bindable public rotation?: 90 | 180 | 270 | '90' | '180' | '270';
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/sizing-icons}
    */
@@ -90,7 +90,7 @@ export class FontAwesomeIconCustomElement {
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/styling/animating-icons}
    */
-  @bindable public spin: boolean = false;
+  @bindable public spin: boolean | 'true' | 'false' = false;
   @bindable public style: any = {};
   /**
    * {@link https://fontawesome.com/how-to-use/on-the-web/advanced/svg-symbols}
@@ -118,14 +118,14 @@ export class FontAwesomeIconCustomElement {
     this.overrideContext = createOverrideContext(bindingContext, overrideContext);
 
     this.classes = {
-      'fa-border': this.border,
+      'fa-border': this.border.toString() === 'true',
       'fa-flip-horizontal': this.flip === 'horizontal' || this.flip === 'both',
       'fa-flip-vertical': this.flip === 'vertical' || this.flip === 'both',
-      'fa-fw': this.fixedWidth,
-      'fa-inverse': this.inverse,
-      'fa-li': this.listItem,
-      'fa-pulse': this.pulse,
-      'fa-spin': this.spin,
+      'fa-fw': this.fixedWidth.toString() === 'true',
+      'fa-inverse': this.inverse.toString() === 'true',
+      'fa-li': this.listItem.toString() === 'true',
+      'fa-pulse': this.pulse.toString() === 'true',
+      'fa-spin': this.spin.toString() === 'true',
       [`fa-${this.size}`]: !!this.size,
       [`fa-pull-${this.pull}`]: !!this.pull,
       [`fa-rotate-${this.rotation}`]: !!this.rotation

--- a/src/font-awesome-icon.ts
+++ b/src/font-awesome-icon.ts
@@ -118,14 +118,14 @@ export class FontAwesomeIconCustomElement {
     this.overrideContext = createOverrideContext(bindingContext, overrideContext);
 
     this.classes = {
-      'fa-border': this.border.toString() === 'true',
+      'fa-border': this.border && this.border.toString() === 'true',
       'fa-flip-horizontal': this.flip === 'horizontal' || this.flip === 'both',
       'fa-flip-vertical': this.flip === 'vertical' || this.flip === 'both',
-      'fa-fw': this.fixedWidth.toString() === 'true',
-      'fa-inverse': this.inverse.toString() === 'true',
-      'fa-li': this.listItem.toString() === 'true',
-      'fa-pulse': this.pulse.toString() === 'true',
-      'fa-spin': this.spin.toString() === 'true',
+      'fa-fw': this.fixedWidth && this.fixedWidth.toString() === 'true',
+      'fa-inverse': this.inverse && this.inverse.toString() === 'true',
+      'fa-li': this.listItem && this.listItem.toString() === 'true',
+      'fa-pulse': this.pulse && this.pulse.toString() === 'true',
+      'fa-spin': this.spin && this.spin.toString() === 'true',
       [`fa-${this.size}`]: !!this.size,
       [`fa-pull-${this.pull}`]: !!this.pull,
       [`fa-rotate-${this.rotation}`]: !!this.rotation

--- a/test/unit/font-awesome-icons.spec.ts
+++ b/test/unit/font-awesome-icons.spec.ts
@@ -129,43 +129,49 @@ describe('the font awesome icon custom element', () => {
     });
   });
 
-  it('uses a border', async done => {
-    /* Arrange */
-    component.inView('<font-awesome-icon icon="coffee" border.bind="true"></font-awesome-icon>');
+  ['', '.bind'].forEach(bind => {
+    it('uses a border', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" border${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-border');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-border');
+      done();
+    });
   });
 
-  it('uses a fixed width', async done => {
-    /* Arrange */
-    component.inView('<font-awesome-icon icon="coffee" fixed-width.bind="true"></font-awesome-icon>');
+  ['', '.bind'].forEach(bind => {
+    it('uses a fixed width', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" fixed-width${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-fw');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-fw');
+      done();
+    });
   });
 
-  it('uses a inverse', async done => {
-    /* Arrange */
-    component.inView('<font-awesome-icon icon="coffee" inverse.bind="true"></font-awesome-icon>');
+  ['', '.bind'].forEach(bind => {
+    it('uses a inverse', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" inverse${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-inverse');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-inverse');
+      done();
+    });
   });
 
   describe('extra element data', () => {
@@ -246,17 +252,19 @@ describe('the font awesome icon custom element', () => {
     });
   });
 
-  it('adds list item', async done => {
-    /* Arrange */
-    component.inView(`<font-awesome-icon icon="coffee" list-item.bind="true"></font-awesome-icon>`);
+  ['', '.bind'].forEach(bind => {
+    it('adds list item', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" list-item${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-li');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-li');
+      done();
+    });
   });
 
   [ 'right', 'left' ].forEach(pull => {
@@ -275,20 +283,22 @@ describe('the font awesome icon custom element', () => {
     });
   });
 
-  it('uses pulse', async done => {
-    /* Arrange */
-    component.inView(`<font-awesome-icon icon="coffee" pulse.bind="true"></font-awesome-icon>`);
+  ['', '.bind'].forEach(bind => {
+    it('uses pulse', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" pulse${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-pulse');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-pulse');
+      done();
+    });
   });
 
-  [ '90', '180', '270' ].forEach(rotation => {
+  [ 90, 180, 270, '90', '180', '270' ].forEach(rotation => {
     it('uses rotation', async done => {
       /* Arrange */
       component.inView(`<font-awesome-icon icon="coffee" rotation.bind="rotation"></font-awesome-icon>`)
@@ -304,17 +314,19 @@ describe('the font awesome icon custom element', () => {
     });
   });
 
-  it('uses spin', async done => {
-    /* Arrange */
-    component.inView(`<font-awesome-icon icon="coffee" spin.bind="true"></font-awesome-icon>`);
+  ['', '.bind'].forEach(bind => {
+    it('uses spin', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" spin${bind}="true"></font-awesome-icon>`);
 
-    /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
 
-    /* Assert */
-    expect($svg.classList).toContain('fa-spin');
-    done();
+      /* Assert */
+      expect($svg.classList).toContain('fa-spin');
+      done();
+    });
   });
 
   [ 'lg', 'xs', 'sm', '1x', '2x', '3x', '4x', '5x', '6x', '7x', '8x', '9x', '10x' ].forEach(size => {


### PR DESCRIPTION
So that one can use e.g. `<font-awesome-icon icon="coffee" fixed-width="true"></font-awesome-icon>` without using `.bind`.