### PR TITLE
feat(customElement): Add bindable property change event handlers

### DIFF
--- a/src/font-awesome-icon.ts
+++ b/src/font-awesome-icon.ts
@@ -3,6 +3,7 @@ import {
   DOM,
   LogManager,
   OverrideContext,
+  View,
   ViewCompiler,
   ViewResources,
   ViewSlot,
@@ -108,73 +109,43 @@ export class FontAwesomeIconCustomElement {
 
   private bindingContext: any;
   private overrideContext: OverrideContext;
-  private classes: any = {};
   private slot: ViewSlot;
   private logger = LogManager.getLogger('aurelia-fontawesome');
+  private iconLookup: any;
+  private view: View;
+  private $i: HTMLElement;
 
   public constructor(private $element: Element,
                      private container: Container,
                      private viewCompiler: ViewCompiler,
                      private resources: ViewResources) { }
 
+   public created() {
+     this.slot = new ViewSlot(this.$element, true);
+   }
+
   public bind(bindingContext: any, overrideContext: OverrideContext) {
     this.bindingContext = bindingContext;
     this.overrideContext = createOverrideContext(bindingContext, overrideContext);
-
-    this.classes = {
-      'fa-border': this.border,
-      'fa-flip-horizontal': this.flip === 'horizontal' || this.flip === 'both',
-      'fa-flip-vertical': this.flip === 'vertical' || this.flip === 'both',
-      'fa-fw': this.fixedWidth,
-      'fa-inverse': this.inverse,
-      'fa-li': this.listItem,
-      'fa-pulse': this.pulse,
-      'fa-spin': this.spin,
-      [`fa-${this.size}`]: !!this.size,
-      [`fa-pull-${this.pull}`]: !!this.pull,
-      [`fa-rotate-${this.rotation}`]: !!this.rotation,
-      [`fa-stack-${this.stack}`]: !!this.stack
-    };
   }
 
   public attached() {
-    this.slot = new ViewSlot(this.$element, true);
+    this.iconLookup = normalizeIconArgs(this.icon);
 
-    const iconLookup = normalizeIconArgs(this.icon);
-
-    if (iconLookup === null) {
-      this.logger.error('Bound icon prop is either unsupported or null', this.icon);
-      return;
-    }
-
-    const classes = objectWithKey('classes', [
-      ...Object.keys(this.classes).filter(key => this.classes[key]),
-      ...this.className.split(' ')
-    ]);
-
-    const transform = objectWithKey(
-      'transform',
-      typeof this.transform === 'string'
-        ? parse.transform(this.transform)
-        : this.transform
-    );
-    const mask = objectWithKey('mask', normalizeIconArgs(this.mask));
-
-    const renderedIcon = icon(iconLookup, {
-      ...classes,
-      ...transform,
-      ...mask,
-      attributes: this.getOtherAttributes(),
-      styles: this.style,
-      symbol: this.symbol,
-      title: this.title
-    });
-
-    if (!renderedIcon) {
-      this.logger.error('Could not find icon', iconLookup);
+    if (this.iconLookup !== null) {
+      this.renderIcon();
     } else {
-      this.compile(renderedIcon.abstract[0]);
+      this.logger.error('Bound icon prop is either unsupported or null', this.icon);
     }
+  }
+
+  public iconChanged() {
+    this.attached();
+  }
+
+  public propertyChanged() {
+    this.detached();
+    this.renderIcon();
   }
 
   public detached(): void {
@@ -185,12 +156,16 @@ export class FontAwesomeIconCustomElement {
 
   protected compile(abstract: AbstractElement): void {
     const $icon = convert(DOM.createElement.bind(DOM), abstract);
-    const $i = DOM.createElement('i');
-    $i.innerHTML = $icon.outerHTML;
-    const factory = this.viewCompiler.compile($i, this.resources);
-    const view = factory.create(this.container, this.bindingContext);
 
-    this.slot.add(view);
+    if (!this.$i) {
+      this.$i = DOM.createElement('i');
+    }
+
+    this.$i.innerHTML = $icon.outerHTML;
+    const factory = this.viewCompiler.compile(this.$i, this.resources);
+    this.view = factory.create(this.container, this.bindingContext);
+
+    this.slot.add(this.view);
     this.slot.bind(this.bindingContext, this.overrideContext);
     this.slot.attached();
   }
@@ -214,5 +189,49 @@ export class FontAwesomeIconCustomElement {
     }
 
     return otherAttrs;
+  }
+
+  private renderIcon() {
+    const classes = {
+      'fa-border': this.border,
+      'fa-flip-horizontal': this.flip === 'horizontal' || this.flip === 'both',
+      'fa-flip-vertical': this.flip === 'vertical' || this.flip === 'both',
+      'fa-fw': this.fixedWidth,
+      'fa-inverse': this.inverse,
+      'fa-li': this.listItem,
+      'fa-pulse': this.pulse,
+      'fa-spin': this.spin,
+      [`fa-${this.size}`]: !!this.size,
+      [`fa-pull-${this.pull}`]: !!this.pull,
+      [`fa-rotate-${this.rotation}`]: !!this.rotation,
+      [`fa-stack-${this.stack}`]: !!this.stack
+    };
+    const classObj =  objectWithKey('classes', [
+      ...Object.keys(classes).filter(key => classes[key]),
+      ...this.className.split(' ')
+    ]);
+    const otherIconParams = {
+      ...objectWithKey('mask', normalizeIconArgs(this.mask)),
+      ...objectWithKey('transform',
+        typeof this.transform === 'string'
+          ? parse.transform(this.transform)
+          : this.transform
+      )
+    }
+
+    const renderedIcon = icon(this.iconLookup, {
+      ...classObj,
+      ...otherIconParams,
+      attributes: this.getOtherAttributes(),
+      styles: this.style,
+      symbol: this.symbol,
+      title: this.title
+    });
+
+    if (!renderedIcon) {
+      this.logger.error('Could not find icon', this.iconLookup);
+    } else {
+      this.compile(renderedIcon.abstract[0]);
+    }
   }
 }

--- a/test/unit/font-awesome-icons.spec.ts
+++ b/test/unit/font-awesome-icons.spec.ts
@@ -12,7 +12,8 @@ import {
   FontAwesomeIconCustomElement
 } from '../../src/aurelia-fontawesome';
 import {
-  createSpyObj
+  createSpyObj,
+  toHyphenCase
 } from './helpers';
 import {
   faCoffee,
@@ -38,7 +39,7 @@ describe('the font awesome icon custom element', () => {
 
   afterEach(() => component.dispose());
 
-  it('binds default properties', async done => {
+  it('binds the default property values', async done => {
     /* Arrange */
     component.inView('<font-awesome-icon icon="coffee"></font-awesome-icon>');
 
@@ -184,6 +185,21 @@ describe('the font awesome icon custom element', () => {
       done();
     });
 
+    it('adds extra attributes', async done => {
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" rel="local"></font-awesome-icon>`);
+
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
+
+      /* Assert */
+      expect($svg.getAttribute('rel')).toEqual('local');
+      done();
+    });
+  });
+
+  describe('using styles', () => {
     it('adds extra styles', async done => {
       /* Arrange */
       const style = { background: 'red' };
@@ -199,18 +215,26 @@ describe('the font awesome icon custom element', () => {
       done();
     });
 
-    it('adds extra attributes', async done => {
+    it('changes the style when updated', async done => {
       /* Arrange */
-      component.inView(`<font-awesome-icon icon="coffee" rel="local"></font-awesome-icon>`);
+      const context = {
+        style: {  },
+      };
+      component.inView(`<font-awesome-icon icon="coffee" style.bind="style">
+                       </font-awesome-icon>`).boundTo(context);
+
+      await component.create(bootstrap);
 
       /* Act */
-      await component.create(bootstrap);
-      const $svg = document.querySelector('svg') as Element;
+      context.style = {
+        background: 'red'
+      };
+      const $svg = await component.waitForElement('svg[style]');
 
       /* Assert */
-      expect($svg.getAttribute('rel')).toEqual('local');
+      expect($svg.getAttribute('style')).toEqual('background: red;');
       done();
-    });
+    }, 6000);
   });
 
   describe('using flip', () => {
@@ -335,6 +359,15 @@ describe('the font awesome icon custom element', () => {
   });
 
   describe('using transform', () => {
+    const transformObj = {
+      flipX: false,
+      flipY: false,
+      rotate: 15,
+      size: 56,
+      x: -4,
+      y: 0
+    };
+
     it('uses a string', async done => {
       /* Arrange */
       component.inView(`<font-awesome-icon icon="coffee" transform="grow-40 left-4 rotate-15">
@@ -351,7 +384,7 @@ describe('the font awesome icon custom element', () => {
 
     it('uses an object', async done => {
       /* Arrange */
-      const transform = { flipX: false, flipY: false, rotate: 15, size: 56, x: -4, y: 0 };
+      const transform = transformObj;
       component.inView(`<font-awesome-icon icon="coffee" transform.bind="transform">
         </font-awesome-icon>`).boundTo({ transform });
 
@@ -363,25 +396,74 @@ describe('the font awesome icon custom element', () => {
       expect($svg.getAttribute('style')).toEqual('transform-origin: 0.375em 0.5em;');
       done();
     });
-  });
 
-  [ { prefix: 'fas', iconName: 'circle' },
-    [ 'fas', 'circle' ],
-    'circle'
-  ].forEach(mask => {
-    it('accepts a mask definition, string or array', async done => {
+    it('updates when the property changes', async done => {
       /* Arrange */
-      component.inView('<font-awesome-icon icon="coffee" mask.bind="mask"></font-awesome-icon>')
-        .boundTo({ mask });
+      const context = {
+        transform: null as any
+      }
+      component.inView(`<font-awesome-icon icon="coffee" transform.bind="transform">
+        </font-awesome-icon>`).boundTo(context);
+
+      await component.create(bootstrap);
 
       /* Act */
-      await component.create(bootstrap);
-      const $svg = document.querySelector('svg') as Element;
-      const $clipPath = $svg.querySelector('clipPath') as Element;
+      context.transform = transformObj;
+
+      const $svg = await component.waitForElement('svg[style]');
 
       /* Assert */
-      expect($clipPath).toBeTruthy();
+      expect($svg.getAttribute('style')).toEqual('transform-origin: 0.375em 0.5em;');
       done();
+    });
+  });
+
+  describe('using mask', () => {
+    const maskArgs = [
+      { prefix: 'fas', iconName: 'circle' },
+      [ 'fas', 'circle' ]
+    ];
+
+    maskArgs.forEach(mask => {
+      it('works with a string or array', async done => {
+        /* Arrange */
+        component.inView('<font-awesome-icon icon="coffee" mask.bind="mask"></font-awesome-icon>')
+          .boundTo({ mask });
+
+        /* Act */
+        await component.create(bootstrap);
+        const $svg = document.querySelector('svg') as Element;
+        const $clipPath = $svg.querySelector('clipPath') as Element;
+
+        /* Assert */
+        expect($clipPath).toBeTruthy();
+        done();
+      });
+    });
+
+    maskArgs.forEach(mask => {
+      it('changes on property update', async done => {
+        /* Arrange */
+        const context = {
+          mask: null as any
+        };
+        component.inView(`<font-awesome-icon icon="coffee" mask.bind="mask">
+                         </font-awesome-icon>`).boundTo(context);
+
+        await component.create(bootstrap);
+        const $svg = document.querySelector('svg') as Element;
+        const $clipPathBefore = $svg.querySelector('clipPath') as Element;
+        expect($clipPathBefore).toBeFalsy();
+
+        /* Act */
+        context.mask = mask
+
+        const $clipPathAfter = await component.waitForElement('clipPath') as Element;
+
+        /* Assert */
+        expect($clipPathAfter).toBeTruthy();
+        done();
+      });
     });
   });
 
@@ -415,38 +497,145 @@ describe('the font awesome icon custom element', () => {
 
       /* Act */
       await component.create(bootstrap);
+      const $symbol = document.querySelector('symbol') as Element;
 
       /* Assert */
+      expect($symbol).toEqual(null);
       expect(spy.mock.calls[0][1].symbol).toEqual(false);
       done();
     });
 
     it('creates a symbol', async done => {
       /* Arrange */
-      component.inView('<font-awesome-icon icon.bind="faCoffee" symbol="coffee-icon"></font-awesome-icon>')
-        .boundTo({ faCoffee });
+      component.inView(`<font-awesome-icon icon.bind="faCoffee" symbol="coffee-icon">
+                       </font-awesome-icon>`).boundTo({ faCoffee });
 
       /* Act */
       await component.create(bootstrap);
+      const $symbol = await component.waitForElement('symbol') as Element;
 
       /* Assert */
-      expect(spy.mock.calls[0][1].symbol).toEqual('coffee-icon');
+      expect($symbol.id).toEqual('coffee-icon');
+      done();
+    }, 6000);
+
+    it('creates a symbol when the property changes', async done => {
+      const context: any = { }
+
+      /* Arrange */
+      component.inView(`<font-awesome-icon icon="coffee" symbol.bind="symbol">
+                       </font-awesome-icon>`).boundTo(context);
+
+      await component.create(bootstrap);
+
+      /* Act */
+      context.symbol = 'coffee-icon';
+
+      const $symbol = await component.waitForElement('symbol') as Element;
+
+      /* Assert */
+      expect($symbol.id).toEqual('coffee-icon');
       done();
     });
   });
 
-  it('adds a title element', async done => {
+  describe('the title property', () => {
+    it('adds a title element', async done => {
+      /* Arrange */
+      component.inView('<font-awesome-icon icon="coffee" title="foobar"></font-awesome-icon>');
+
+      /* Act */
+      await component.create(bootstrap);
+      const $svg = document.querySelector('svg') as Element;
+
+      expect($svg.children[0].tagName).toEqual('title');
+      expect($svg.children[0].textContent).toEqual('foobar');
+      done();
+    });
+
+    it('changes the title name when the prop changes', async done => {
+      /* Arrange */
+      const context = {
+        title: ''
+      }
+      component.inView(`<font-awesome-icon icon="coffee" title.bind="title">
+                       </font-awesome-icon>`).boundTo(context);
+
+      /* Act */
+      await component.create(bootstrap);
+
+      context.title = 'bar';
+
+      const $title = await component.waitForElement('title');
+
+      expect($title).not.toEqual(null);
+      expect($title.textContent).toEqual('bar');
+      done();
+    });
+  });
+
+  [{ prop: 'border', val: true, className: 'fa-border' },
+   { prop: 'fixedWidth', val: true, className: 'fa-fw' },
+   { prop: 'flip', val: 'horizontal', className: 'fa-flip-horizontal' },
+   { prop: 'flip', val: 'vertical', className: 'fa-flip-vertical' },
+   { prop: 'flip', val: 'both', className: 'fa-flip-horizontal' },
+   { prop: 'flip', val: 'both', className: 'fa-flip-vertical' },
+   { prop: 'inverse', val: true, className: 'fa-inverse' },
+   { prop: 'listItem', val: true, className: 'fa-li' },
+   { prop: 'pull', val: 'right', className: 'fa-pull-right' },
+   { prop: 'pull', val: 'left', className: 'fa-pull-left' },
+   { prop: 'pulse', val: true, className: 'fa-pulse' },
+   { prop: 'rotation', val: 90, className: 'fa-rotate-90' },
+   { prop: 'rotation', val: 180, className: 'fa-rotate-180' },
+   { prop: 'rotation', val: 270, className: 'fa-rotate-270' },
+   { prop: 'size', val: 'lg', className: 'fa-lg' },
+   { prop: 'spin', val: true, className: 'fa-spin' },
+   { prop: 'stack', val: '1x', className: 'fa-stack-1x' }
+  ].forEach(rec => {
+    it('recompiles when any bindable property changes', async done => {
+      /* Arrange */
+      const context = {
+        [rec.prop]: null
+      };
+      component
+        .inView(`<font-awesome-icon icon="coffee"
+                ${toHyphenCase(rec.prop)}.bind="${rec.prop}"></font-awesome-icon>`)
+        .boundTo(context);
+
+      await component.create(bootstrap);
+      const $beforePropChange = document.querySelector('svg') as Element;
+
+      /* Act */
+      context[rec.prop] = rec.val as any;
+
+      expect($beforePropChange.classList).not.toContain(rec.className);
+
+      const $afterPropChange = await component.waitForElement(`.${rec.className}`);
+
+      expect($afterPropChange.classList).toContain(rec.className);
+      done();
+    }, 6000);
+  });
+
+  it('recompiles when the icon when it changes', async done => {
     /* Arrange */
-    component.inView('<font-awesome-icon icon="coffee" title="foobar"></font-awesome-icon>');
+    const context = {
+      icon: 'coffee'
+    };
+    component
+      .inView('<font-awesome-icon icon.bind="icon"></font-awesome-icon>')
+      .boundTo(context);
+
+    await component.create(bootstrap);
 
     /* Act */
-    await component.create(bootstrap);
-    const $svg = document.querySelector('svg') as Element;
+    context.icon = 'circle';
 
-    expect($svg.children[0].tagName).toEqual('title');
-    expect($svg.children[0].textContent).toEqual('foobar');
+    const $afterPropChange = await component.waitForElement('.fa-circle');
+
+    expect($afterPropChange.classList).toContain('fa-circle');
     done();
-  });
+  }, 6000);
 
   it('uses an <i> instead of <template> to support IE', async done => {
     /* Arrange */

--- a/test/unit/font-awesome-icons.spec.ts
+++ b/test/unit/font-awesome-icons.spec.ts
@@ -634,20 +634,27 @@ describe('the font awesome icon custom element', () => {
     const $afterPropChange = await component.waitForElement('.fa-circle');
 
     expect($afterPropChange.classList).toContain('fa-circle');
+    expect(document.querySelectorAll('font-awesome-icon').length).toEqual(1);
     done();
   }, 6000);
 
-  it('uses an <i> instead of <template> to support IE', async done => {
+  it('only creates one icon', async done => {
     /* Arrange */
-    component.inView('<font-awesome-icon icon="coffee"></font-awesome-icon>');
+    const context = {
+      icon: 'coffee'
+    };
+    component
+      .inView('<font-awesome-icon icon.bind="icon"></font-awesome-icon>')
+      .boundTo(context);
     await component.create(bootstrap);
 
     /* Act */
-    const $i = component.element.querySelector('i');
+    context.icon = 'circle';
 
+    await component.waitForElement('.fa-circle');
+    const $icons = document.querySelectorAll('svg');
     /* Assert */
-    expect($i).not.toEqual(null);
-    expect(($i as HTMLElement).children[0].tagName).toEqual('svg');
+    expect($icons.length).toEqual(1);
     done();
   });
 });

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,3 +1,11 @@
+export const toCamelCase = (str: string ): string => {
+  return str.replace(/(?:^\w|[A-Z]|\b\w|[\s+\-_\/])/g, function(match, index) {
+    //remove white space or hypens or underscores
+    if (/[\s+\-_\/]/.test(match)) return '';
+    return index === 0 ? match.toLowerCase() : match.toUpperCase();
+  });
+};
+
 export function createSpyObj(name: string, prototype: any) {
   if (!prototype) {
     throw Error('obj to fake required');
@@ -14,3 +22,10 @@ export function createSpyObj(name: string, prototype: any) {
 
   return obj;
 }
+
+export const toHyphenCase = (str: string): string => {
+  const camel = toCamelCase(str);
+
+  return camel.replace(/[A-Z]/, (match, offset) =>
+    (offset ? '-' : '') + match.toLowerCase());
+};


### PR DESCRIPTION
Use the `propertyChanged` method called by Aurelia for every prop, but
the icon. There can be some optimizations added later, such as adding a
`maskChanged` or `transformChanged`, since these need to run additional logic,
but it seems minimal right now.

When the icon changes it needs to be normalized before it is rendered,
therefore it has to call the `attached` method first in the
`iconChanged` method.

Some of the logic was moved from attached to a private `renderIcon` function 
so both `propertyChanged` and `iconChanged` can call it.

Some unit tests were reorganized into their own `describe` when there was more than one test as a result of the property change tests

closes #5