### PR TITLE
fix(customElement): replace template tag with i

### DIFF
--- a/src/font-awesome-icon.ts
+++ b/src/font-awesome-icon.ts
@@ -185,9 +185,9 @@ export class FontAwesomeIconCustomElement {
 
   protected compile(abstract: AbstractElement): void {
     const $icon = convert(DOM.createElement.bind(DOM), abstract);
-    const $template = DOM.createElement('template');
-    $template.innerHTML = $icon.outerHTML;
-    const factory = this.viewCompiler.compile($template, this.resources);
+    const $i = DOM.createElement('i');
+    $i.innerHTML = $icon.outerHTML;
+    const factory = this.viewCompiler.compile($i, this.resources);
     const view = factory.create(this.container, this.bindingContext);
 
     this.slot.add(view);

--- a/test/unit/font-awesome-icons.spec.ts
+++ b/test/unit/font-awesome-icons.spec.ts
@@ -447,4 +447,18 @@ describe('the font awesome icon custom element', () => {
     expect($svg.children[0].textContent).toEqual('foobar');
     done();
   });
+
+  it('uses an <i> instead of <template> to support IE', async done => {
+    /* Arrange */
+    component.inView('<font-awesome-icon icon="coffee"></font-awesome-icon>');
+    await component.create(bootstrap);
+
+    /* Act */
+    const $i = component.element.querySelector('i');
+
+    /* Assert */
+    expect($i).not.toEqual(null);
+    expect(($i as HTMLElement).children[0].tagName).toEqual('svg');
+    done();
+  });
 });


### PR DESCRIPTION
This fixes a bug where the icon cannot render in IE where the `template` is invalid